### PR TITLE
Dockerfile: Add missing x11 packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
 	apt-get install -yq sudo build-essential git \
 	  python python3 man bash diffstat gawk chrpath wget cpio \
 	  texinfo lzop apt-utils bc screen libncurses5-dev locales \
-          libc6-dev-i386 doxygen libssl-dev dos2unix \
+          libc6-dev-i386 doxygen libssl-dev dos2unix xvfb x11-utils \
 	  g++-multilib libssl-dev:i386 libcrypto++-dev:i386 zlib1g-dev:i386 && \
 	rm -rf /var/lib/apt-lists/* && \
 	echo "dash dash/sh boolean false" | debconf-set-selections && \


### PR DESCRIPTION
Add the missing x11 packages required for build.

Signed-off-by: Sanchayan Maity <maitysanchayan@gmail.com>